### PR TITLE
Kto 1060

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
     <properties>
         <scala.version>2.12.10</scala.version>
 
-        <kouta-indeksoija.version>5.0.0-SNAPSHOT</kouta-indeksoija.version>
-        <kouta-backend.version>5.0.0-SNAPSHOT</kouta-backend.version>
+        <kouta-indeksoija.version>7.0.0-SNAPSHOT</kouta-indeksoija.version>
+        <kouta-backend.version>6.2.0-SNAPSHOT</kouta-backend.version>
         <kouta-common.version>2.2.0-SNAPSHOT</kouta-common.version>
 
         <!-- Korjaa käännösvirheen:

--- a/src/main/scala/fi/oph/kouta/internal/domain/Valintaperuste.scala
+++ b/src/main/scala/fi/oph/kouta/internal/domain/Valintaperuste.scala
@@ -48,6 +48,7 @@ import fi.oph.kouta.internal.swagger.SwaggerModel
     |          example: haunkohdejoukontarkenne_1#1
     |        sorakuvausId:
     |          type: string
+    |          deprecated: true
     |          description: Valintaperustekuvaukseen liittyvän SORA-kuvauksen yksilöivä tunniste
     |          example: "ea596a9c-5940-497e-b5b7-aded3a2352a7"
     |        julkinen:
@@ -145,7 +146,7 @@ case class Valintaperuste(
     kohdejoukonTarkenneKoodiUri: Option[String],
     nimi: Kielistetty,
     julkinen: Boolean,
-    sorakuvausId: Option[UUID],
+    @deprecated("Kenttä siirretty koulutukselle") sorakuvausId: Option[UUID],
     metadata: Option[ValintaperusteMetadata],
     organisaatioOid: OrganisaatioOid,
     muokkaaja: UserOid,

--- a/src/main/scala/fi/oph/kouta/internal/domain/indexed/valintaperuste.scala
+++ b/src/main/scala/fi/oph/kouta/internal/domain/indexed/valintaperuste.scala
@@ -17,7 +17,7 @@ case class ValintaperusteIndexed(
     kohdejoukonTarkenne: Option[KoodiUri],
     nimi: Kielistetty,
     julkinen: Boolean,
-    sorakuvaus: Option[SorakuvausIndexed],
+    @deprecated("Kenttä siirretty koulutukselle") sorakuvaus: Option[SorakuvausIndexed],
     metadata: Option[ValintaperusteMetadataIndexed],
     organisaatio: Option[Organisaatio],
     muokkaaja: Muokkaaja,

--- a/src/test/scala/fi/oph/kouta/internal/integration/HakukohdeSpec.scala
+++ b/src/test/scala/fi/oph/kouta/internal/integration/HakukohdeSpec.scala
@@ -33,7 +33,8 @@ class HakukohdeSpec
     super.beforeAll()
 
     addMockHaku(hakuOid, ParentOid)
-    addMockKoulutus(koulutusOid, ParentOid)
+    addMockSorakuvaus(sorakuvausId, ChildOid)
+    addMockKoulutus(koulutusOid, ParentOid, sorakuvausId)
     addMockToteutus(toteutusId, ParentOid, koulutusOid)
 
     addMockSorakuvaus(sorakuvausId, ChildOid)

--- a/src/test/scala/fi/oph/kouta/internal/integration/HakukohdeSpec.scala
+++ b/src/test/scala/fi/oph/kouta/internal/integration/HakukohdeSpec.scala
@@ -37,8 +37,7 @@ class HakukohdeSpec
     addMockKoulutus(koulutusOid, ParentOid, sorakuvausId)
     addMockToteutus(toteutusId, ParentOid, koulutusOid)
 
-    addMockSorakuvaus(sorakuvausId, ChildOid)
-    addMockValintaperuste(valintaperusteId, ChildOid, sorakuvausId)
+    addMockValintaperuste(valintaperusteId, ChildOid)
 
     addMockHakukohde(existingId, ChildOid, hakuOid, toteutusId, valintaperusteId, jarjestyspaikkaOid = ChildOid)
   }

--- a/src/test/scala/fi/oph/kouta/internal/integration/KoulutusSpec.scala
+++ b/src/test/scala/fi/oph/kouta/internal/integration/KoulutusSpec.scala
@@ -4,15 +4,19 @@ import fi.oph.kouta.internal.domain.oid.KoulutusOid
 import fi.oph.kouta.internal.integration.fixture.{AccessControlSpec, KoulutusFixture}
 import fi.oph.kouta.internal.security.Role
 
+import java.util.UUID
+
 class KoulutusSpec extends KoulutusFixture with AccessControlSpec {
 
   override val roleEntities      = Seq(Role.Koulutus)
   val existingId: KoulutusOid    = KoulutusOid("1.2.246.562.13.00000000000000000009")
   val nonExistingId: KoulutusOid = KoulutusOid("1.2.246.562.13.0")
+  val sorakuvausId: UUID         = UUID.fromString("9267884f-fba1-4b85-8bb3-3eb77440c197")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    addMockKoulutus(existingId, ChildOid)
+    addMockSorakuvaus(sorakuvausId, ChildOid)
+    addMockKoulutus(existingId, ChildOid, sorakuvausId)
   }
 
   "GET /:id" should s"get koulutus from elastic search" in {
@@ -35,13 +39,13 @@ class KoulutusSpec extends KoulutusFixture with AccessControlSpec {
 
   it should "get ammatillinen tutkinnon osa koulutus" in {
     val tutkinnonOsaOid = KoulutusOid("1.2.246.562.13.00000000000000000019")
-    addMockTutkinnonOsaKoulutus(tutkinnonOsaOid, ChildOid)
+    addMockTutkinnonOsaKoulutus(tutkinnonOsaOid, ChildOid, sorakuvausId)
     get(tutkinnonOsaOid, defaultSessionId)
   }
 
   it should "get ammatillinen osaamisala koulutus" in {
     val osaamisalaOid = KoulutusOid("1.2.246.562.13.00000000000000000020")
-    addMockOsaamisalaKoulutus(osaamisalaOid, ChildOid)
+    addMockOsaamisalaKoulutus(osaamisalaOid, ChildOid, sorakuvausId)
     get(osaamisalaOid, defaultSessionId)
   }
 }

--- a/src/test/scala/fi/oph/kouta/internal/integration/ToteutusSpec.scala
+++ b/src/test/scala/fi/oph/kouta/internal/integration/ToteutusSpec.scala
@@ -4,6 +4,8 @@ import fi.oph.kouta.internal.domain.oid.{KoulutusOid, ToteutusOid}
 import fi.oph.kouta.internal.integration.fixture.{AccessControlSpec, KoulutusFixture, ToteutusFixture}
 import fi.oph.kouta.internal.security.Role
 
+import java.util.UUID
+
 class ToteutusSpec extends ToteutusFixture with KoulutusFixture with AccessControlSpec {
 
   override val roleEntities      = Seq(Role.Toteutus)
@@ -11,10 +13,12 @@ class ToteutusSpec extends ToteutusFixture with KoulutusFixture with AccessContr
   val nonExistingId: ToteutusOid = ToteutusOid("1.2.246.562.17.0")
 
   val koulutusOid: KoulutusOid = KoulutusOid("1.2.246.562.13.789")
+  val sorakuvausId: UUID       = UUID.fromString("9267884f-fba1-4b85-8bb3-3eb77440c197")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    addMockKoulutus(koulutusOid, ChildOid)
+    addMockSorakuvaus(sorakuvausId, ChildOid)
+    addMockKoulutus(koulutusOid, ChildOid, sorakuvausId)
     addMockToteutus(existingId, ChildOid, koulutusOid)
   }
 
@@ -39,7 +43,7 @@ class ToteutusSpec extends ToteutusFixture with KoulutusFixture with AccessContr
   it should "get tutkinnon osa toteutus" in {
     val tutkinnonOsaOid = ToteutusOid("1.2.246.562.17.791")
     val koulutusOid     = KoulutusOid("1.2.246.562.13.792")
-    addMockTutkinnonOsaKoulutus(koulutusOid, ChildOid)
+    addMockTutkinnonOsaKoulutus(koulutusOid, ChildOid, sorakuvausId)
     addMockTutkinnonOsaToteutus(tutkinnonOsaOid, ChildOid, koulutusOid)
     get(tutkinnonOsaOid, defaultSessionId)
   }
@@ -47,7 +51,7 @@ class ToteutusSpec extends ToteutusFixture with KoulutusFixture with AccessContr
   it should "get osaamisala toteutus" in {
     val tutkinnonOsaOid = ToteutusOid("1.2.246.562.17.793")
     val koulutusOid     = KoulutusOid("1.2.246.562.13.794")
-    addMockOsaamisalaKoulutus(koulutusOid, ChildOid)
+    addMockOsaamisalaKoulutus(koulutusOid, ChildOid, sorakuvausId)
     addMockOsaamisalaToteutus(tutkinnonOsaOid, ChildOid, koulutusOid)
     get(tutkinnonOsaOid, defaultSessionId)
   }

--- a/src/test/scala/fi/oph/kouta/internal/integration/ValintaperusteSpec.scala
+++ b/src/test/scala/fi/oph/kouta/internal/integration/ValintaperusteSpec.scala
@@ -16,12 +16,10 @@ class ValintaperusteSpec
   override val entityName: String  = "valintaperuste"
   override val existingId: UUID    = UUID.fromString("03715370-2c2e-40b1-adf9-4de9e4eb3c73")
   override val nonExistingId: UUID = UUID.fromString("cc76da4a-d4cb-4ef2-a5d1-34b14c1a64bd")
-  val sorakuvausId                 = UUID.fromString("9267884f-fba1-4b85-8bb3-3eb77440c197")
 
   override def beforeAll(): Unit = {
     super.beforeAll()
-    addMockSorakuvaus(sorakuvausId, ChildOid)
-    addMockValintaperuste(existingId, ChildOid, sorakuvausId)
+    addMockValintaperuste(existingId, ChildOid)
   }
 
   getTests()

--- a/src/test/scala/fi/oph/kouta/internal/integration/fixture/KoulutusFixture.scala
+++ b/src/test/scala/fi/oph/kouta/internal/integration/fixture/KoulutusFixture.scala
@@ -30,16 +30,20 @@ trait KoulutusFixture extends KoutaIntegrationSpec {
 
   def addMockKoulutus(
       koulutusOid: KoulutusOid,
-      organisaatioOid: OrganisaatioOid = OrganisaatioServiceMock.ChildOid
+      organisaatioOid: OrganisaatioOid = OrganisaatioServiceMock.ChildOid,
+      sorakuvausId: UUID
   ): Unit = {
-    val koulutus = KoutaFixtureTool.DefaultKoulutusScala + (KoutaFixtureTool.OrganisaatioKey -> organisaatioOid.s)
+    val koulutus = KoutaFixtureTool.DefaultKoulutusScala +
+      (KoutaFixtureTool.OrganisaatioKey -> organisaatioOid.s) +
+      (KoutaFixtureTool.SorakuvausIdKey -> sorakuvausId.toString)
     KoutaFixtureTool.addKoulutus(koulutusOid.s, koulutus)
     indexKoulutus(koulutusOid)
   }
 
   def addMockTutkinnonOsaKoulutus(
       koulutusOid: KoulutusOid,
-      organisaatioOid: OrganisaatioOid = OrganisaatioServiceMock.ChildOid
+      organisaatioOid: OrganisaatioOid = OrganisaatioServiceMock.ChildOid,
+      sorakuvausId: UUID
   ): Unit = {
     val koulutus = KoutaFixtureTool.DefaultKoulutusScala +
       (KoutaFixtureTool.MetadataKey            -> KoutaFixtureTool.ammTutkinnonOsaKoulutusMetadata) +
@@ -47,21 +51,30 @@ trait KoulutusFixture extends KoutaIntegrationSpec {
       (KoutaFixtureTool.JohtaaTutkintoonKey    -> "false") +
       (KoutaFixtureTool.EPerusteIdKey          -> null) +
       (KoutaFixtureTool.KoulutuksetKoodiUriKey -> null) +
-      (KoutaFixtureTool.OrganisaatioKey        -> organisaatioOid.s)
+      (KoutaFixtureTool.OrganisaatioKey        -> organisaatioOid.s) +
+      (KoutaFixtureTool.SorakuvausIdKey        -> sorakuvausId.toString)
     KoutaFixtureTool.addKoulutus(koulutusOid.s, koulutus)
     indexKoulutus(koulutusOid)
   }
 
   def addMockOsaamisalaKoulutus(
       koulutusOid: KoulutusOid,
-      organisaatioOid: OrganisaatioOid = OrganisaatioServiceMock.ChildOid
+      organisaatioOid: OrganisaatioOid = OrganisaatioServiceMock.ChildOid,
+      sorakuvausId: UUID
   ): Unit = {
     val koulutus = KoutaFixtureTool.DefaultKoulutusScala +
       (KoutaFixtureTool.MetadataKey         -> KoutaFixtureTool.ammOsaamisalaKoulutusMetadata) +
       (KoutaFixtureTool.KoulutustyyppiKey   -> AmmOsaamisala.name) +
       (KoutaFixtureTool.JohtaaTutkintoonKey -> "false") +
-      (KoutaFixtureTool.OrganisaatioKey     -> organisaatioOid.s)
+      (KoutaFixtureTool.OrganisaatioKey     -> organisaatioOid.s) +
+      (KoutaFixtureTool.SorakuvausIdKey     -> sorakuvausId.toString)
     KoutaFixtureTool.addKoulutus(koulutusOid.s, koulutus)
     indexKoulutus(koulutusOid)
+  }
+
+  def addMockSorakuvaus(id: UUID, organisaatioOid: OrganisaatioOid): Unit = {
+    val sorakuvaus = KoutaFixtureTool.DefaultSorakuvausScala + (KoutaFixtureTool.OrganisaatioKey -> organisaatioOid.s)
+    KoutaFixtureTool.addSorakuvaus(id.toString, sorakuvaus)
+    indexSorakuvaus(id)
   }
 }

--- a/src/test/scala/fi/oph/kouta/internal/integration/fixture/ValintaperusteFixture.scala
+++ b/src/test/scala/fi/oph/kouta/internal/integration/fixture/ValintaperusteFixture.scala
@@ -29,19 +29,11 @@ trait ValintaperusteFixture extends KoutaIntegrationSpec {
 
   def addMockValintaperuste(
       id: UUID,
-      organisaatioOid: OrganisaatioOid,
-      sorakuvausId: UUID
+      organisaatioOid: OrganisaatioOid
   ): Unit = {
     val valintaperuste = KoutaFixtureTool.DefaultValintaperusteScala +
-      (KoutaFixtureTool.OrganisaatioKey -> organisaatioOid.s) +
-      (KoutaFixtureTool.SorakuvausIdKey -> sorakuvausId.toString)
+      (KoutaFixtureTool.OrganisaatioKey -> organisaatioOid.s)
     KoutaFixtureTool.addValintaperuste(id.toString, valintaperuste)
     indexValintaperuste(id)
-  }
-
-  def addMockSorakuvaus(id: UUID, organisaatioOid: OrganisaatioOid) = {
-    val sorakuvaus = KoutaFixtureTool.DefaultSorakuvausScala + (KoutaFixtureTool.OrganisaatioKey -> organisaatioOid.s)
-    KoutaFixtureTool.addSorakuvaus(id.toString, sorakuvaus)
-    indexSorakuvaus(id)
   }
 }


### PR DESCRIPTION
- Merkattu valintaperusteen sorakuvaus deprekoituneeksi, tämä kenttä indeksoidaan nykyään koulutukselle mutta ei lisätä internaliin ennen kuin kentälle on käyttöä
- Nostettu kouta-backendin ja indeksoijan versioita
